### PR TITLE
feat: add floor tab with table grid

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import PongTimerDashboard from "@/components/dashboard/pong-timer-dashboard"
+import SpaceOpsApp from "@/components/dashboard/space-ops-app"
 import { createServer } from "@/lib/supabase/server"
 
 export const revalidate = 0
@@ -15,9 +15,8 @@ export default async function HomePage() {
   }
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-4 md:p-8 lg:p-12 bg-black bg-grid-white/[0.05] relative">
-      <div className="absolute pointer-events-none inset-0 flex items-center justify-center bg-black [mask-image:radial-gradient(ellipse_at_center,transparent_20%,black)]"></div>
-      <PongTimerDashboard serverTables={tables ?? []} />
+    <main className="min-h-screen">
+      <SpaceOpsApp serverTables={tables ?? []} />
     </main>
   )
 }

--- a/components/dashboard/space-ops-app.tsx
+++ b/components/dashboard/space-ops-app.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useSupabase } from "../providers/supabase-provider"
+import { useTableStore } from "@/stores/table-store"
+import CustomizableTableGrid from "./customizable-table-grid"
+import StoreInitializer from "../providers/store-initializer"
+import type { Table, Session } from "@/lib/types"
+
+export type TableWithSessions = Table & { sessions: Session[] }
+
+export default function SpaceOpsApp({ serverTables }: { serverTables: TableWithSessions[] }) {
+  const { supabase } = useSupabase()
+  const { updateTable, updateSession } = useTableStore()
+  const [route, setRoute] = useState("dashboard")
+
+  useEffect(() => {
+    const channel = supabase
+      .channel("realtime-tables")
+      .on("postgres_changes", { event: "*", schema: "public", table: "ping_pong_tables" }, (payload) =>
+        updateTable(payload.new as Table),
+      )
+      .on("postgres_changes", { event: "*", schema: "public", table: "sessions" }, (payload) =>
+        updateSession(payload.new as Session),
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [supabase, updateTable, updateSession])
+
+  return (
+    <div className="flex h-screen bg-background text-foreground">
+      <StoreInitializer tables={serverTables} />
+      <aside className="w-60 border-r border-border p-4 flex flex-col gap-2">
+        <button
+          className={`text-left p-2 rounded hover:bg-accent ${route === "dashboard" ? "bg-accent" : ""}`}
+          onClick={() => setRoute("dashboard")}
+        >
+          Dashboard
+        </button>
+        <button
+          className={`text-left p-2 rounded hover:bg-accent ${route === "floor" ? "bg-accent" : ""}`}
+          onClick={() => setRoute("floor")}
+        >
+          Floor
+        </button>
+        <button className="text-left p-2 rounded hover:bg-accent" onClick={() => setRoute("automations")}>Automations</button>
+        <button className="text-left p-2 rounded hover:bg-accent" onClick={() => setRoute("inventory")}>Inventory</button>
+        <button className="text-left p-2 rounded hover:bg-accent" onClick={() => setRoute("tasks")}>Tasks</button>
+        <button className="text-left p-2 rounded hover:bg-accent" onClick={() => setRoute("schedule")}>Schedule</button>
+        <button className="text-left p-2 rounded hover:bg-accent" onClick={() => setRoute("settings")}>Settings</button>
+      </aside>
+      <section className="flex-1 flex flex-col">
+        <header className="p-4 border-b border-border flex items-center justify-between">
+          <div className="font-semibold">Space Ops</div>
+          <input
+            className="max-w-sm w-full ml-4 p-2 rounded bg-background border border-border"
+            placeholder="Search..."
+          />
+        </header>
+        <div className="flex-1 overflow-auto p-4">
+          {route === "dashboard" && <div className="text-muted-foreground">Dashboard coming soon</div>}
+          {route === "floor" && <CustomizableTableGrid />}
+          {route === "automations" && <div className="text-muted-foreground">Automations coming soon</div>}
+          {route === "inventory" && <div className="text-muted-foreground">Inventory coming soon</div>}
+          {route === "tasks" && <div className="text-muted-foreground">Tasks coming soon</div>}
+          {route === "schedule" && <div className="text-muted-foreground">Schedule coming soon</div>}
+          {route === "settings" && <div className="text-muted-foreground">Settings coming soon</div>}
+        </div>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- replace original dashboard page with new Space Ops shell
- add sidebar navigation with Floor tab rendering existing table grid

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68abd9a4719883299370aa1b047b9613