### PR TITLE
feat: scaffold dashboard views

### DIFF
--- a/components/dashboard/automations-view.tsx
+++ b/components/dashboard/automations-view.tsx
@@ -1,0 +1,49 @@
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+
+interface Workflow {
+  id: string
+  name: string
+  desc: string
+  status: string
+}
+
+export default function AutomationsView() {
+  const workflows: Workflow[] = [
+    { id: "spotify-playlist", name: "Spotify Playlist Control", desc: "Control venue music via Spotify", status: "ready" },
+    { id: "music-vibe", name: "Set Music Vibe", desc: "Spotify → Chill playlist", status: "ready" },
+    { id: "table-timer", name: "Table Timer Alert", desc: "Notify when session ends", status: "ready" },
+    { id: "daily-report", name: "Daily Revenue Report", desc: "Generate end-of-day summary", status: "ready" },
+  ]
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-base font-semibold">Workflows (Spotify Enabled)</CardTitle>
+        <div className="flex gap-2">
+          <Button variant="secondary">+ New Workflow</Button>
+          <Button>Deploy</Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {workflows.map((w) => (
+          <div key={w.id} className="flex items-center justify-between rounded-md border p-3">
+            <div>
+              <div className="font-medium">{w.name}</div>
+              <div className="text-sm text-muted-foreground">{w.desc}</div>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-muted-foreground">
+                {w.status === "ready" ? "✅ Ready" : "⛔ Needs attention"}
+              </span>
+              <Button size="sm">Run</Button>
+              <Button size="sm" variant="outline">
+                Details
+              </Button>
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/dashboard/inventory-view.tsx
+++ b/components/dashboard/inventory-view.tsx
@@ -1,0 +1,71 @@
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+
+interface Item {
+  name: string
+  on: number
+  par: number
+  vendor: string
+  status: "OK" | "Low" | "Critical"
+}
+
+export default function InventoryView() {
+  const items: Item[] = [
+    { name: "Ping Pong Balls (24ct)", on: 18, par: 36, vendor: "SportsPro", status: "Low" },
+    { name: "San Pellegrino 500ml", on: 42, par: 60, vendor: "BeverageHub", status: "OK" },
+    { name: "Lime Juice (1L)", on: 3, par: 12, vendor: "BarMart", status: "Critical" },
+    { name: "Pool Cue Tips", on: 8, par: 20, vendor: "BilliardSupply", status: "Low" },
+  ]
+
+  const statusClasses: Record<Item["status"], string> = {
+    OK: "bg-green-500/15 text-green-300",
+    Low: "bg-amber-500/15 text-amber-300",
+    Critical: "bg-red-500/15 text-red-300",
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-base font-semibold">Inventory</CardTitle>
+        <div className="flex gap-2">
+          <Button variant="outline">Recalc PAR</Button>
+          <Button>Create PO</Button>
+        </div>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-xs text-muted-foreground">
+              <th className="p-2">Item</th>
+              <th className="p-2">On Hand</th>
+              <th className="p-2">PAR</th>
+              <th className="p-2">Vendor</th>
+              <th className="p-2">Status</th>
+              <th className="p-2">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((it) => (
+              <tr key={it.name} className="border-b last:border-none">
+                <td className="p-2 font-medium">{it.name}</td>
+                <td className="p-2">{it.on}</td>
+                <td className="p-2">{it.par}</td>
+                <td className="p-2">{it.vendor}</td>
+                <td className="p-2">
+                  <span className={`rounded-full px-2 py-0.5 text-xs ${statusClasses[it.status]}`}>
+                    {it.status}
+                  </span>
+                </td>
+                <td className="p-2">
+                  <Button size="sm" variant="secondary">
+                    Reorder
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/dashboard/schedule-view.tsx
+++ b/components/dashboard/schedule-view.tsx
@@ -1,0 +1,33 @@
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+
+export default function ScheduleView() {
+  const days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+  const events: Record<string, string[]> = {
+    Wed: ["6PM - Lee Park"],
+    Fri: ["7PM - Team Event"],
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-base font-semibold">Schedule Management</CardTitle>
+        <Button>+ New Booking</Button>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-7 gap-2">
+          {days.map((d) => (
+            <div key={d} className="rounded-md border p-2 min-h-[100px]">
+              <div className="mb-2 font-medium">{d}</div>
+              {events[d]?.map((ev) => (
+                <div key={ev} className="mb-1 rounded bg-primary/15 px-2 py-1 text-xs">
+                  {ev}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/dashboard/settings-view.tsx
+++ b/components/dashboard/settings-view.tsx
@@ -1,0 +1,65 @@
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+
+function ToggleRow({ label, defaultChecked }: { label: string; defaultChecked?: boolean }) {
+  return (
+    <div className="flex items-center justify-between rounded-md border p-2">
+      <span>{label}</span>
+      <input
+        type="checkbox"
+        defaultChecked={defaultChecked}
+        className="h-5 w-9 rounded-full border bg-muted checked:bg-primary"
+      />
+    </div>
+  )
+}
+
+export default function SettingsView() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base font-semibold">System Settings</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <section className="space-y-2">
+          <h4 className="font-medium">General</h4>
+          <div className="flex items-center justify-between rounded-md border p-2">
+            <span>Venue Name</span>
+            <input
+              defaultValue="Space Ping Pong"
+              className="w-48 rounded-md border bg-background p-1"
+            />
+          </div>
+          <div className="flex items-center justify-between rounded-md border p-2">
+            <span>Default Session Length</span>
+            <select className="w-48 rounded-md border bg-background p-1">
+              <option>60 min</option>
+              <option selected>90 min</option>
+              <option>120 min</option>
+            </select>
+          </div>
+        </section>
+
+        <section className="space-y-2">
+          <h4 className="font-medium">Automation</h4>
+          <ToggleRow label="Auto-run workflows" defaultChecked />
+          <ToggleRow label="Spotify integration" defaultChecked />
+          <ToggleRow label="Supabase sync" defaultChecked />
+        </section>
+
+        <section className="space-y-2">
+          <h4 className="font-medium">Notifications</h4>
+          <ToggleRow label="Email notifications" />
+          <ToggleRow label="SMS alerts" />
+        </section>
+
+        <div className="flex flex-wrap gap-2 pt-2">
+          <Button>Save Settings</Button>
+          <Button variant="secondary">Export Config</Button>
+          <Button variant="secondary">Import Config</Button>
+          <Button variant="destructive">Reset to Default</Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/dashboard/space-ops-app.tsx
+++ b/components/dashboard/space-ops-app.tsx
@@ -6,6 +6,11 @@ import { useTableStore } from "@/stores/table-store"
 import CustomizableTableGrid from "./customizable-table-grid"
 import StoreInitializer from "../providers/store-initializer"
 import type { Table, Session } from "@/lib/types"
+import AutomationsView from "./automations-view"
+import InventoryView from "./inventory-view"
+import TasksView from "./tasks-view"
+import ScheduleView from "./schedule-view"
+import SettingsView from "./settings-view"
 
 export type TableWithSessions = Table & { sessions: Session[] }
 
@@ -46,11 +51,36 @@ export default function SpaceOpsApp({ serverTables }: { serverTables: TableWithS
         >
           Floor
         </button>
-        <button className="text-left p-2 rounded hover:bg-accent" onClick={() => setRoute("automations")}>Automations</button>
-        <button className="text-left p-2 rounded hover:bg-accent" onClick={() => setRoute("inventory")}>Inventory</button>
-        <button className="text-left p-2 rounded hover:bg-accent" onClick={() => setRoute("tasks")}>Tasks</button>
-        <button className="text-left p-2 rounded hover:bg-accent" onClick={() => setRoute("schedule")}>Schedule</button>
-        <button className="text-left p-2 rounded hover:bg-accent" onClick={() => setRoute("settings")}>Settings</button>
+        <button
+          className={`text-left p-2 rounded hover:bg-accent ${route === "automations" ? "bg-accent" : ""}`}
+          onClick={() => setRoute("automations")}
+        >
+          Automations
+        </button>
+        <button
+          className={`text-left p-2 rounded hover:bg-accent ${route === "inventory" ? "bg-accent" : ""}`}
+          onClick={() => setRoute("inventory")}
+        >
+          Inventory
+        </button>
+        <button
+          className={`text-left p-2 rounded hover:bg-accent ${route === "tasks" ? "bg-accent" : ""}`}
+          onClick={() => setRoute("tasks")}
+        >
+          Tasks
+        </button>
+        <button
+          className={`text-left p-2 rounded hover:bg-accent ${route === "schedule" ? "bg-accent" : ""}`}
+          onClick={() => setRoute("schedule")}
+        >
+          Schedule
+        </button>
+        <button
+          className={`text-left p-2 rounded hover:bg-accent ${route === "settings" ? "bg-accent" : ""}`}
+          onClick={() => setRoute("settings")}
+        >
+          Settings
+        </button>
       </aside>
       <section className="flex-1 flex flex-col">
         <header className="p-4 border-b border-border flex items-center justify-between">
@@ -63,11 +93,11 @@ export default function SpaceOpsApp({ serverTables }: { serverTables: TableWithS
         <div className="flex-1 overflow-auto p-4">
           {route === "dashboard" && <div className="text-muted-foreground">Dashboard coming soon</div>}
           {route === "floor" && <CustomizableTableGrid />}
-          {route === "automations" && <div className="text-muted-foreground">Automations coming soon</div>}
-          {route === "inventory" && <div className="text-muted-foreground">Inventory coming soon</div>}
-          {route === "tasks" && <div className="text-muted-foreground">Tasks coming soon</div>}
-          {route === "schedule" && <div className="text-muted-foreground">Schedule coming soon</div>}
-          {route === "settings" && <div className="text-muted-foreground">Settings coming soon</div>}
+          {route === "automations" && <AutomationsView />}
+          {route === "inventory" && <InventoryView />}
+          {route === "tasks" && <TasksView />}
+          {route === "schedule" && <ScheduleView />}
+          {route === "settings" && <SettingsView />}
         </div>
       </section>
     </div>

--- a/components/dashboard/tasks-view.tsx
+++ b/components/dashboard/tasks-view.tsx
@@ -1,0 +1,32 @@
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+
+export default function TasksView() {
+  const tasks = {
+    backlog: ["Add billiards pricing", "Update karaoke song list"],
+    doing: ["Configure floor plan editor", "Integrate Spotify API"],
+    done: ["Install security cameras", "Set up POS system"],
+  }
+
+  const Column = ({ title, items }: { title: string; items: string[] }) => (
+    <Card className="flex-1">
+      <CardHeader>
+        <CardTitle className="text-base font-semibold">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {items.map((t) => (
+          <div key={t} className="rounded-md border p-2 text-sm">
+            {t}
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+
+  return (
+    <div className="grid gap-4 md:grid-cols-3">
+      <Column title="Backlog" items={tasks.backlog} />
+      <Column title="Doing" items={tasks.doing} />
+      <Column title="Done" items={tasks.done} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add placeholder views for Automations, Inventory, Tasks, Schedule, and Settings using shadcn/ui
- wire navigation to render new views with active tab highlighting

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68abe08f80808329b09af89978caf688