### PR TITLE
feat: apply space ops dashboard styling

### DIFF
--- a/components/dashboard/automations-view.tsx
+++ b/components/dashboard/automations-view.tsx
@@ -1,0 +1,42 @@
+interface Workflow {
+  id: string;
+  name: string;
+  desc: string;
+  status: string;
+}
+
+export default function AutomationsView() {
+  const workflows: Workflow[] = [
+    { id: "spotify-playlist", name: "Spotify Playlist Control", desc: "Control venue music via Spotify", status: "ready" },
+    { id: "music-vibe", name: "Set Music Vibe", desc: "Spotify → Chill playlist", status: "ready" },
+    { id: "table-timer", name: "Table Timer Alert", desc: "Notify when session ends", status: "ready" },
+    { id: "daily-report", name: "Daily Revenue Report", desc: "Generate end-of-day summary", status: "ready" },
+  ];
+
+  return (
+    <div className="card">
+      <div className="row" style={{ justifyContent: "space-between" }}>
+        <h3 style={{ margin: 0 }}>Workflows (Spotify Enabled)</h3>
+        <div className="row">
+          <button className="btn primary">➕ New Workflow</button>
+          <button className="btn">⬆️ Deploy</button>
+        </div>
+      </div>
+      <div className="list">
+        {workflows.map((w) => (
+          <div key={w.id} className="item">
+            <div>
+              <strong>{w.name}</strong>
+              <div className="muted">{w.desc}</div>
+            </div>
+            <div className="row">
+              <span className="muted">{w.status === "ready" ? "✅ Ready" : "⛔ Needs attention"}</span>
+              <button className="btn">Run</button>
+              <button className="btn">Details</button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/dashboard-view.tsx
+++ b/components/dashboard/dashboard-view.tsx
@@ -1,0 +1,119 @@
+export default function DashboardView() {
+  const schedule = [
+    { time: "6:00 PM", duration: "90 min", name: "Lee Park", guests: 2, salesType: "Walk-in", details: "Table 4 requested" },
+    { time: "6:30 PM", duration: "60 min", name: "Chen Wu", guests: 3, salesType: "Online", details: "Birthday party" },
+    { time: "7:00 PM", duration: "120 min", name: "Kim Davis", guests: 5, salesType: "Member", details: "VIP member" },
+  ];
+  const activity = [
+    "Table P2 session started",
+    "Spotify playlist changed to \"Evening Vibes\"",
+    "New reservation: Kim Davis @ 7PM",
+    "Low inventory alert: Pool Cue Tips",
+  ];
+  return (
+    <>
+      <div className="grid kpis">
+        <div className="card">
+          <div className="weather-widget">
+            <h3>Weather</h3>
+            <div className="weather-main">
+              <span className="weather-icon">☀️</span>
+              <div className="weather-info">
+                <span className="weather-temp">72°F</span>
+                <span className="weather-desc">Clear skies</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="card">
+          <h3>Active Tables</h3>
+          <div className="big">7</div>
+          <div className="muted">+2 since 1 hr ago</div>
+        </div>
+        <div className="card">
+          <h3>Avg Session</h3>
+          <div className="big">01:12</div>
+          <div className="muted">All activities</div>
+        </div>
+        <div className="card">
+          <h3>Revenue Today</h3>
+          <div className="big">$4,820</div>
+          <div className="muted">Target $6,500</div>
+        </div>
+      </div>
+      <div className="split">
+        <div className="card">
+          <div className="row" style={{ justifyContent: "space-between" }}>
+            <div className="row"><h3 style={{ margin: 0 }}>Quick Actions</h3></div>
+            <div className="tabs" role="tablist">
+              <button className="tab active">🏓 Ping Pong</button>
+              <button className="tab">⛳ iGolf</button>
+              <button className="tab">🎤 Karaoke</button>
+              <button className="tab">🎱 Billiards</button>
+            </div>
+          </div>
+          <div className="row" style={{ marginTop: 10 }}>
+            <button className="btn primary">➕ Start Session</button>
+            <button className="btn">📅 Schedule</button>
+            <button className="btn">📝 Order Form</button>
+            <button className="btn">🎵 Play Vibe</button>
+          </div>
+        </div>
+        <div className="card">
+          <h3>Recent Activity</h3>
+          <div className="list">
+            {activity.map((e) => (
+              <div key={e} className="item">
+                <div>{e}</div>
+                <button className="btn">👁️</button>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="card">
+        <div className="row" style={{ justifyContent: "space-between" }}>
+          <h3 style={{ margin: 0 }}>Today's Reservations</h3>
+          <button className="btn">📅 Pull from Google Calendar</button>
+        </div>
+        <div className="location-buttons">
+          <button className="location-btn active">🏓 Ping Pong</button>
+          <button className="location-btn">⛳ iGolf</button>
+          <button className="location-btn">🎤 Karaoke</button>
+          <button className="location-btn">🎱 Billiards</button>
+        </div>
+        <table className="table" aria-label="Reservations">
+          <thead>
+            <tr>
+              <th>Time (Duration)</th>
+              <th>Name (Host)</th>
+              <th>Guests</th>
+              <th>Sales Type</th>
+              <th>Details</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {schedule.map((r) => (
+              <tr key={r.time}>
+                <td>{r.time} ({r.duration})</td>
+                <td>{r.name}</td>
+                <td>{r.guests}</td>
+                <td>{r.salesType}</td>
+                <td>{r.details}</td>
+                <td>
+                  <div className="action-btns">
+                    <button className="icon-btn" title="Edit">✏️</button>
+                    <button className="icon-btn" title="SMS">📱</button>
+                    <button className="icon-btn" title="Email">📧</button>
+                    <button className="icon-btn" title="Memo">📝</button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/components/dashboard/inventory-view.tsx
+++ b/components/dashboard/inventory-view.tsx
@@ -1,0 +1,62 @@
+interface Item {
+  name: string;
+  on: number;
+  par: number;
+  vendor: string;
+  status: "OK" | "Low" | "Critical";
+}
+
+export default function InventoryView() {
+  const items: Item[] = [
+    { name: "Ping Pong Balls (24ct)", on: 18, par: 36, vendor: "SportsPro", status: "Low" },
+    { name: "San Pellegrino 500ml", on: 42, par: 60, vendor: "BeverageHub", status: "OK" },
+    { name: "Lime Juice (1L)", on: 3, par: 12, vendor: "BarMart", status: "Critical" },
+    { name: "Pool Cue Tips", on: 8, par: 20, vendor: "BilliardSupply", status: "Low" },
+  ];
+
+  const statusClass: Record<Item["status"], string> = {
+    OK: "status s-ok",
+    Low: "status s-busy",
+    Critical: "status s-off",
+  };
+
+  return (
+    <div className="card">
+      <div className="row" style={{ justifyContent: "space-between" }}>
+        <h3 style={{ margin: 0 }}>Inventory</h3>
+        <div className="row">
+          <button className="btn">🧮 Recalc PAR</button>
+          <button className="btn primary">📝 Create PO</button>
+        </div>
+      </div>
+      <table className="table" aria-label="Inventory">
+        <thead>
+          <tr>
+            <th>Item</th>
+            <th>On Hand</th>
+            <th>PAR</th>
+            <th>Vendor</th>
+            <th>Status</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((it) => (
+            <tr key={it.name}>
+              <td>{it.name}</td>
+              <td>{it.on}</td>
+              <td>{it.par}</td>
+              <td>{it.vendor}</td>
+              <td>
+                <span className={statusClass[it.status]}>{it.status}</span>
+              </td>
+              <td>
+                <button className="btn" style={{ padding: "6px 10px" }}>🛒 Reorder</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/dashboard/schedule-view.tsx
+++ b/components/dashboard/schedule-view.tsx
@@ -1,0 +1,26 @@
+export default function ScheduleView() {
+  const days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+  const events: Record<string, string[]> = {
+    Wed: ["6PM - Lee Park"],
+    Fri: ["7PM - Team Event"],
+  };
+
+  return (
+    <div className="card">
+      <div className="row" style={{ justifyContent: "space-between" }}>
+        <h3 style={{ margin: 0 }}>Schedule Management</h3>
+        <button className="btn primary">➕ New Booking</button>
+      </div>
+      <div className="schedule-calendar">
+        {days.map((d) => (
+          <div key={d} className="calendar-day">
+            <div className="calendar-day-header">{d}</div>
+            {events[d]?.map((ev) => (
+              <div key={ev} className="calendar-event">{ev}</div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/settings-view.tsx
+++ b/components/dashboard/settings-view.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+
+export default function SettingsView() {
+  const [settings, setSettings] = useState({
+    autoRun: true,
+    spotify: true,
+    supabase: true,
+    email: false,
+    sms: false,
+  });
+
+  const toggle = (key: keyof typeof settings) =>
+    setSettings((s) => ({ ...s, [key]: !s[key] }));
+
+  return (
+    <div className="card">
+      <h3>System Settings</h3>
+
+      <div className="settings-section">
+        <h4>General</h4>
+        <div className="setting-item">
+          <span>Venue Name</span>
+          <input defaultValue="Space Ping Pong" style={{ background: "#0b1220", color: "var(--text)", border: "1px solid rgba(255,255,255,.12)", borderRadius: 8, padding: 8 }} />
+        </div>
+        <div className="setting-item">
+          <span>Default Session Length</span>
+          <select style={{ background: "#0b1220", color: "var(--text)", border: "1px solid rgba(255,255,255,.12)", borderRadius: 8, padding: 8 }}>
+            <option>60 min</option>
+            <option selected>90 min</option>
+            <option>120 min</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="settings-section">
+        <h4>Automation</h4>
+        <div className="setting-item">
+          <span>Auto-run workflows</span>
+          <div className={`toggle-switch ${settings.autoRun ? "active" : ""}`} onClick={() => toggle("autoRun")}></div>
+        </div>
+        <div className="setting-item">
+          <span>Spotify integration</span>
+          <div className={`toggle-switch ${settings.spotify ? "active" : ""}`} onClick={() => toggle("spotify")}></div>
+        </div>
+        <div className="setting-item">
+          <span>Supabase sync</span>
+          <div className={`toggle-switch ${settings.supabase ? "active" : ""}`} onClick={() => toggle("supabase")}></div>
+        </div>
+      </div>
+
+      <div className="settings-section">
+        <h4>Notifications</h4>
+        <div className="setting-item">
+          <span>Email notifications</span>
+          <div className={`toggle-switch ${settings.email ? "active" : ""}`} onClick={() => toggle("email")}></div>
+        </div>
+        <div className="setting-item">
+          <span>SMS alerts</span>
+          <div className={`toggle-switch ${settings.sms ? "active" : ""}`} onClick={() => toggle("sms")}></div>
+        </div>
+      </div>
+
+      <div className="row" style={{ marginTop: 20 }}>
+        <button className="btn primary">💾 Save Settings</button>
+        <button className="btn">📤 Export Config</button>
+        <button className="btn">📥 Import Config</button>
+        <button className="btn danger">🔄 Reset to Default</button>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/space-ops-app.tsx
+++ b/components/dashboard/space-ops-app.tsx
@@ -1,11 +1,18 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import "@/styles/space-ops.css"
 import { useSupabase } from "../providers/supabase-provider"
 import { useTableStore } from "@/stores/table-store"
 import CustomizableTableGrid from "./customizable-table-grid"
 import StoreInitializer from "../providers/store-initializer"
 import type { Table, Session } from "@/lib/types"
+import DashboardView from "./dashboard-view"
+import AutomationsView from "./automations-view"
+import InventoryView from "./inventory-view"
+import TasksView from "./tasks-view"
+import ScheduleView from "./schedule-view"
+import SettingsView from "./settings-view"
 
 export type TableWithSessions = Table & { sessions: Session[] }
 
@@ -13,6 +20,8 @@ export default function SpaceOpsApp({ serverTables }: { serverTables: TableWithS
   const { supabase } = useSupabase()
   const { updateTable, updateSession } = useTableStore()
   const [route, setRoute] = useState("dashboard")
+  const [collapsed, setCollapsed] = useState(false)
+  const [dayStarted, setDayStarted] = useState(false)
 
   useEffect(() => {
     const channel = supabase
@@ -31,43 +40,63 @@ export default function SpaceOpsApp({ serverTables }: { serverTables: TableWithS
   }, [supabase, updateTable, updateSession])
 
   return (
-    <div className="flex h-screen bg-background text-foreground">
+    <div className="app">
       <StoreInitializer tables={serverTables} />
-      <aside className="w-60 border-r border-border p-4 flex flex-col gap-2">
-        <button
-          className={`text-left p-2 rounded hover:bg-accent ${route === "dashboard" ? "bg-accent" : ""}`}
-          onClick={() => setRoute("dashboard")}
-        >
-          Dashboard
-        </button>
-        <button
-          className={`text-left p-2 rounded hover:bg-accent ${route === "floor" ? "bg-accent" : ""}`}
-          onClick={() => setRoute("floor")}
-        >
-          Floor
-        </button>
-        <button className="text-left p-2 rounded hover:bg-accent" onClick={() => setRoute("automations")}>Automations</button>
-        <button className="text-left p-2 rounded hover:bg-accent" onClick={() => setRoute("inventory")}>Inventory</button>
-        <button className="text-left p-2 rounded hover:bg-accent" onClick={() => setRoute("tasks")}>Tasks</button>
-        <button className="text-left p-2 rounded hover:bg-accent" onClick={() => setRoute("schedule")}>Schedule</button>
-        <button className="text-left p-2 rounded hover:bg-accent" onClick={() => setRoute("settings")}>Settings</button>
+      <aside className={`sidebar ${collapsed ? "collapsed" : ""}`}>
+        <button className="toggle-sidebar" onClick={() => setCollapsed(!collapsed)}>☰</button>
+        <div className="brand">
+          <div className="logo" onClick={() => setRoute("dashboard")}></div>
+          <h1>SPACE OPS</h1>
+        </div>
+        <div className="nav">
+          <button className={route === "dashboard" ? "active" : ""} onClick={() => setRoute("dashboard")}>🏠 <span className="label">Dashboard</span></button>
+          <button className={route === "floor" ? "active" : ""} onClick={() => setRoute("floor")}>🎯 <span className="label">Floor</span></button>
+          <button className={route === "automations" ? "active" : ""} onClick={() => setRoute("automations")}>⚙️ <span className="label">Automations</span></button>
+          <button className={route === "inventory" ? "active" : ""} onClick={() => setRoute("inventory")}>📦 <span className="label">Inventory</span></button>
+          <button className={route === "tasks" ? "active" : ""} onClick={() => setRoute("tasks")}>🗂️ <span className="label">Tasks</span></button>
+          <button className={route === "schedule" ? "active" : ""} onClick={() => setRoute("schedule")}>📅 <span className="label">Schedule</span></button>
+          <button className={route === "settings" ? "active" : ""} onClick={() => setRoute("settings")}>🛠️ <span className="label">Settings</span></button>
+        </div>
       </aside>
-      <section className="flex-1 flex flex-col">
-        <header className="p-4 border-b border-border flex items-center justify-between">
-          <div className="font-semibold">Space Ops</div>
-          <input
-            className="max-w-sm w-full ml-4 p-2 rounded bg-background border border-border"
-            placeholder="Search..."
-          />
-        </header>
-        <div className="flex-1 overflow-auto p-4">
-          {route === "dashboard" && <div className="text-muted-foreground">Dashboard coming soon</div>}
-          {route === "floor" && <CustomizableTableGrid />}
-          {route === "automations" && <div className="text-muted-foreground">Automations coming soon</div>}
-          {route === "inventory" && <div className="text-muted-foreground">Inventory coming soon</div>}
-          {route === "tasks" && <div className="text-muted-foreground">Tasks coming soon</div>}
-          {route === "schedule" && <div className="text-muted-foreground">Schedule coming soon</div>}
-          {route === "settings" && <div className="text-muted-foreground">Settings coming soon</div>}
+      <section className="main">
+        <div className="topbar">
+          <div className="search" role="search">
+            🔎 <input placeholder="Search..." aria-label="Search" />
+            <div className="search-buttons">
+              <button className="search-btn" title="Voice Search">🎤</button>
+              <button className="search-btn" title="Upload Image">📷</button>
+              <button className="search-btn" title="AI Mode">🤖</button>
+            </div>
+          </div>
+          <button className="btn ghost" onClick={() => document.body.classList.toggle("light")}>🌗 Theme</button>
+          <button className="btn">🔄 Sync</button>
+          <button className="btn primary" onClick={() => setDayStarted(!dayStarted)}>
+            {dayStarted ? "🌙 End Day" : "🌅 Start Day"}
+          </button>
+          <div className="avatar" onClick={() => setRoute("dashboard")}>S</div>
+        </div>
+        <div className="views">
+          <div className={`view ${route === "dashboard" ? "active" : ""}`} id="view-dashboard">
+            <DashboardView />
+          </div>
+          <div className={`view ${route === "floor" ? "active" : ""}`} id="view-floor">
+            <CustomizableTableGrid />
+          </div>
+          <div className={`view ${route === "automations" ? "active" : ""}`} id="view-automations">
+            <AutomationsView />
+          </div>
+          <div className={`view ${route === "inventory" ? "active" : ""}`} id="view-inventory">
+            <InventoryView />
+          </div>
+          <div className={`view ${route === "tasks" ? "active" : ""}`} id="view-tasks">
+            <TasksView />
+          </div>
+          <div className={`view ${route === "schedule" ? "active" : ""}`} id="view-schedule">
+            <ScheduleView />
+          </div>
+          <div className={`view ${route === "settings" ? "active" : ""}`} id="view-settings">
+            <SettingsView />
+          </div>
         </div>
       </section>
     </div>

--- a/components/dashboard/tasks-view.tsx
+++ b/components/dashboard/tasks-view.tsx
@@ -1,0 +1,28 @@
+export default function TasksView() {
+  const tasks = {
+    backlog: ["Add billiards pricing", "Update karaoke song list"],
+    doing: ["Configure floor plan editor", "Integrate Spotify API"],
+    done: ["Install security cameras", "Set up POS system"],
+  };
+
+  const Column = ({ title, items }: { title: string; items: string[] }) => (
+    <div className="card">
+      <h3>{title}</h3>
+      <div className="list">
+        {items.map((t) => (
+          <div key={t} className="item">
+            <div>{t}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="grid tasks-cols gap-4">
+      <Column title="Backlog" items={tasks.backlog} />
+      <Column title="Doing" items={tasks.doing} />
+      <Column title="Done" items={tasks.done} />
+    </div>
+  );
+}

--- a/styles/space-ops.css
+++ b/styles/space-ops.css
@@ -1,0 +1,123 @@
+:root{
+    --bg:#0b0f14;
+    --bg-2:#0d1219;
+    --surface:#121826;
+    --elev:#0f1522;
+    --text:#e6f1ff;
+    --muted:#9bb0c9;
+    --primary:#00e5ff;
+    --primary-2:#8a2be2;
+    --ok:#34d399;
+    --warn:#f59e0b;
+    --bad:#ef4444;
+    --glow:0 0 24px rgba(0,229,255,.35), 0 0 8px rgba(138,43,226,.25);
+    --radius:14px;
+    --shadow:0 10px 30px rgba(0,0,0,.35);
+}
+*{box-sizing:border-box}
+html,body{height:100%}
+body{
+    margin:0;
+    font:14px/1.5 ui-sans-serif,-apple-system,Segoe UI,Roboto,Inter,"Helvetica Neue",Arial,system-ui;
+    color:var(--text);
+    background:radial-gradient(1200px 800px at 10% -20%,rgba(0,229,255,.08),transparent 60%),radial-gradient(1000px 700px at 120% 10%,rgba(138,43,226,.08),transparent 50%),linear-gradient(180deg,var(--bg),var(--bg-2));
+}
+a{color:inherit;text-decoration:none}
+.app{
+    display:grid;
+    grid-template-columns:260px 1fr;
+    min-height:100dvh;
+    position:relative;
+}
+.sidebar{
+    position:sticky;top:0;align-self:start;
+    height:100dvh;
+    background:linear-gradient(180deg,rgba(18,24,38,.9),rgba(18,24,38,.6));
+    border-right:1px solid rgba(255,255,255,.06);
+    padding:18px 16px;
+    backdrop-filter:blur(10px);
+    transition:width .3s ease,transform .3s ease;
+    overflow:hidden;width:260px;
+}
+.sidebar.collapsed{width:72px}
+.toggle-sidebar{position:absolute;right:10px;top:10px;background:rgba(255,255,255,.05);border:1px solid rgba(255,255,255,.08);border-radius:8px;padding:4px 8px;cursor:pointer;transition:.18s ease}
+.toggle-sidebar:hover{background:rgba(255,255,255,.1);border-color:rgba(0,229,255,.5)}
+.brand{display:flex;align-items:center;gap:12px;padding:10px 8px;margin-bottom:10px;position:relative}
+.logo{width:36px;height:36px;border-radius:10px;background:linear-gradient(135deg,#00e5ff,#8a2be2);box-shadow:var(--glow);position:relative;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:20px;font-weight:bold;color:white}
+.logo:after{content:"S";position:absolute;font-family:'Arial Black',sans-serif}
+.brand h1{font-size:15px;letter-spacing:.2em;margin:0;text-transform:uppercase;color:#c9e7ff;white-space:nowrap}
+.sidebar.collapsed .brand h1{display:none}
+.nav{margin-top:8px;display:flex;flex-direction:column;gap:6px}
+.nav button{appearance:none;border:0;background:transparent;color:var(--text);text-align:left;padding:12px 12px;border-radius:12px;display:flex;align-items:center;gap:10px;transition:.18s ease;cursor:pointer;white-space:nowrap;overflow:hidden}
+.nav button:hover{background:#182236}
+.nav button.active{background:linear-gradient(90deg,rgba(0,229,255,.15),rgba(138,43,226,.08));box-shadow:var(--glow)}
+.nav .tag{margin-left:auto;font-size:12px;opacity:.8;padding:2px 8px;border-radius:999px;background:#182236}
+.sidebar.collapsed .nav .label,.sidebar.collapsed .nav .tag{display:none}
+.sidebar .mini{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin:14px 2px}
+.sidebar.collapsed .mini{grid-template-columns:1fr}
+.chip{padding:10px 12px;border:1px solid rgba(255,255,255,.08);border-radius:12px;background:#0e1524;cursor:pointer;text-align:center;overflow:hidden}
+.chip:hover{border-color:rgba(0,229,255,.5);box-shadow:var(--glow)}
+.sidebar.collapsed .chip .muted{display:none}
+.foot{position:absolute;bottom:14px;left:16px;right:16px;opacity:.9;font-size:12px;border-top:1px solid rgba(255,255,255,.08);padding-top:10px}
+.sidebar.collapsed .foot{display:none}
+.main{min-width:0;display:flex;flex-direction:column}
+.topbar{position:sticky;top:0;z-index:5;display:flex;align-items:center;gap:12px;padding:12px 16px;border-bottom:1px solid rgba(255,255,255,.06);background:linear-gradient(180deg,rgba(11,15,20,.8),rgba(11,15,20,.45));backdrop-filter:blur(6px)}
+.search{flex:1;display:flex;align-items:center;gap:10px;background:#0e1524;border:1px solid rgba(255,255,255,.08);border-radius:999px;padding:8px 12px;position:relative}
+.search input{border:0;background:transparent;color:var(--text);outline:none;width:100%}
+.search-buttons{display:flex;gap:8px;align-items:center}
+.search-btn{background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.1);border-radius:8px;padding:6px 10px;cursor:pointer;transition:.18s ease;font-size:12px}
+.search-btn:hover{background:rgba(0,229,255,.15);border-color:rgba(0,229,255,.5)}
+.btn{appearance:none;border:1px solid rgba(255,255,255,.1);background:#101826;color:var(--text);padding:10px 14px;border-radius:12px;cursor:pointer;transition:.18s ease;display:inline-flex;align-items:center;gap:8px}
+.btn:hover{border-color:rgba(0,229,255,.6);box-shadow:var(--glow)}
+.btn.primary{background:linear-gradient(90deg,rgba(0,229,255,.15),rgba(138,43,226,.15));border-color:rgba(0,229,255,.35)}
+.btn.ghost{background:transparent}
+.btn.danger{background:rgba(239,68,68,.15);border-color:rgba(239,68,68,.35)}
+.avatar{width:36px;height:36px;border-radius:10px;background:linear-gradient(135deg,#00e5ff,#8a2be2);cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:bold;color:white;box-shadow:var(--glow)}
+.views{padding:18px;display:grid;gap:18px}
+.view{display:none}
+.view.active{display:block}
+.grid{display:grid;gap:16px}
+.kpis{grid-template-columns:repeat(4,minmax(0,1fr))}
+.card{background:linear-gradient(180deg,rgba(16,24,38,.9),rgba(16,24,38,.7));border:1px solid rgba(255,255,255,.08);border-radius:var(--radius);box-shadow:var(--shadow);padding:16px;min-height:72px}
+.card h3{margin:0 0 8px 0;font-weight:600;font-size:14px;color:#cde6ff}
+.big{font-size:28px;font-weight:700;letter-spacing:.5px}
+.muted{color:var(--muted)}
+.row{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+.split{display:grid;grid-template-columns:1.2fr .8fr;gap:16px}
+.floor-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:16px}
+.location-selector{display:flex;gap:8px;align-items:center}
+.location-dropdown{background:#0e1524;border:1px solid rgba(255,255,255,.08);color:var(--text);padding:8px 12px;border-radius:8px;cursor:pointer}
+.location-buttons{display:flex;gap:8px;margin:12px 0}
+.location-btn{padding:8px 16px;border:1px solid rgba(255,255,255,.08);background:#0e1524;color:var(--text);border-radius:8px;cursor:pointer;transition:.18s ease}
+.location-btn:hover,.location-btn.active{background:rgba(0,229,255,.15);border-color:rgba(0,229,255,.5)}
+.status{font-size:12px;padding:4px 8px;border-radius:999px;width:max-content}
+.s-ok{background:rgba(52,211,153,.15);color:#a7f3d0}
+.s-busy{background:rgba(245,158,11,.15);color:#fde68a}
+.s-off{background:rgba(239,68,68,.15);color:#fecaca}
+.list{display:grid;gap:8px}
+.item{padding:12px;border-radius:12px;background:#0f1525;border:1px solid rgba(255,255,255,.06);display:flex;align-items:center;gap:12px;justify-content:space-between}
+.tabs{display:flex;gap:8px;flex-wrap:wrap}
+.tab{padding:8px 12px;border-radius:999px;border:1px solid rgba(255,255,255,.08);background:#0e1524;cursor:pointer}
+.tab.active{border-color:rgba(0,229,255,.6);box-shadow:var(--glow)}
+.table{width:100%;border-collapse:separate;border-spacing:0 8px}
+.table th{font-size:12px;color:#b9d7ff;text-align:left;padding:8px 10px}
+.table td{background:#0f1525;border:1px solid rgba(255,255,255,.06);padding:10px;border-left-width:1px;border-right-width:1px}
+.table tr td:first-child{border-top-left-radius:10px;border-bottom-left-radius:10px}
+.table tr td:last-child{border-top-right-radius:10px;border-bottom-right-radius:10px}
+.action-btns{display:flex;gap:4px}
+.icon-btn{padding:6px;border-radius:6px;background:rgba(255,255,255,.05);border:1px solid rgba(255,255,255,.08);cursor:pointer;transition:.18s ease}
+.icon-btn:hover{background:rgba(0,229,255,.15);border-color:rgba(0,229,255,.5)}
+.settings-section{margin-bottom:24px}
+.settings-section h4{color:#c9e7ff;margin-bottom:12px;font-size:16px}
+.setting-item{display:flex;justify-content:space-between;align-items:center;padding:12px;background:#0f1525;border:1px solid rgba(255,255,255,.06);border-radius:10px;margin-bottom:8px}
+.toggle-switch{position:relative;width:48px;height:24px;background:#182236;border-radius:999px;cursor:pointer;transition:.3s ease}
+.toggle-switch.active{background:var(--primary)}
+.toggle-switch:after{content:'';position:absolute;width:20px;height:20px;background:white;border-radius:50%;top:2px;left:2px;transition:.3s ease}
+.toggle-switch.active:after{transform:translateX(24px)}
+.schedule-calendar{display:grid;grid-template-columns:repeat(7,1fr);gap:8px;margin-top:16px}
+.calendar-day{padding:12px;background:#0f1525;border:1px solid rgba(255,255,255,.06);border-radius:10px;min-height:100px}
+.calendar-day-header{font-weight:bold;color:#c9e7ff;margin-bottom:8px}
+.calendar-event{font-size:12px;padding:4px 6px;background:rgba(0,229,255,.15);border-radius:6px;margin-bottom:4px}
+.grid.tasks-cols{grid-template-columns:repeat(3,minmax(0,1fr))}
+@media (max-width:960px){.app{grid-template-columns:72px 1fr}.sidebar{width:72px}.brand h1{display:none}.nav .label{display:none}.split{grid-template-columns:1fr}}
+@media (max-width:560px){.kpis{grid-template-columns:repeat(2,minmax(0,1fr))}}


### PR DESCRIPTION
## Summary
- integrate Space Ops HTML theme in global stylesheet and layout
- build styled dashboard view with KPI cards, quick actions, and reservations
- restyle Automations, Inventory, Tasks, Schedule, and Settings to match new UI

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68abe08f80808329b09af89978caf688