### PR TITLE
refactor dashboard cards into components

### DIFF
--- a/components/dashboard/dashboard-view.tsx
+++ b/components/dashboard/dashboard-view.tsx
@@ -1,11 +1,12 @@
 "use client"
 
-import { Card } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
 import WeatherCard from "./weather-card"
 import ActiveTablesCard from "./active-tables-card"
 import AvgSessionCard from "./avg-session-card"
 import RevenueCard from "./revenue-card"
+import QuickActionsCard from "./quick-actions-card"
+import RecentActivityCard from "./recent-activity-card"
+import TodaysReservationsCard from "./todays-reservations-card"
 
 export default function DashboardView() {
   return (
@@ -20,158 +21,13 @@ export default function DashboardView() {
 
       {/* Quick Actions + Recent Activity */}
       <div className="grid gap-4 lg:grid-cols-2">
-        <Card className="glass-card p-4">
-          <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
-            <h3 className="font-medium">Quick Actions</h3>
-            <div className="flex gap-2" role="tablist">
-              <Button size="sm" className="rounded-full bg-accent px-3 py-1 text-sm hover:bg-accent">
-                🏓 Ping Pong
-              </Button>
-              <Button size="sm" variant="ghost" className="rounded-full px-3 py-1 text-sm hover:bg-accent">
-                ⛳ iGolf
-              </Button>
-              <Button size="sm" variant="ghost" className="rounded-full px-3 py-1 text-sm hover:bg-accent">
-                🎤 Karaoke
-              </Button>
-              <Button size="sm" variant="ghost" className="rounded-full px-3 py-1 text-sm hover:bg-accent">
-                🎱 Billiards
-              </Button>
-            </div>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <Button variant="outline" size="sm">
-              ➕ Start Session
-            </Button>
-            <Button variant="outline" size="sm">
-              📅 Schedule
-            </Button>
-            <Button variant="outline" size="sm">
-              📝 Order Form
-            </Button>
-            <Button variant="outline" size="sm">
-              🎵 Play Vibe
-            </Button>
-          </div>
-        </Card>
-
-        <Card className="glass-card p-4">
-          <h3 className="mb-4 font-medium">Recent Activity</h3>
-          <div className="grid gap-2">
-            <div className="flex items-center justify-between rounded-md border p-2">
-              <span>Table P2 session started</span>
-              <Button variant="outline" size="sm">
-                👁️
-              </Button>
-            </div>
-            <div className="flex items-center justify-between rounded-md border p-2">
-              <span>Spotify playlist changed</span>
-              <Button variant="outline" size="sm">
-                👁️
-              </Button>
-            </div>
-            <div className="flex items-center justify-between rounded-md border p-2">
-              <span>New reservation: Kim Davis</span>
-              <Button variant="outline" size="sm">
-                👁️
-              </Button>
-            </div>
-            <div className="flex items-center justify-between rounded-md border p-2">
-              <span>Low inventory alert: Pool Cue Tips</span>
-              <Button variant="outline" size="sm">
-                👁️
-              </Button>
-            </div>
-          </div>
-        </Card>
+        <QuickActionsCard />
+        <RecentActivityCard />
       </div>
 
       {/* Today's Reservations */}
-      <Card className="glass-card p-4">
-        <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
-          <h3 className="font-medium">Today's Reservations</h3>
-          <Button variant="outline" size="sm" className="px-3 py-1">
-            📅 Pull from Google Calendar
-          </Button>
-        </div>
-        <div className="mb-4 flex flex-wrap gap-2">
-          <Button size="sm" className="rounded-md bg-accent px-3 py-1 text-sm">
-            🏓 Ping Pong
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            className="rounded-md px-3 py-1 text-sm hover:bg-accent"
-          >
-            ⛳ iGolf
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            className="rounded-md px-3 py-1 text-sm hover:bg-accent"
-          >
-            🎤 Karaoke
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            className="rounded-md px-3 py-1 text-sm hover:bg-accent"
-          >
-            🎱 Billiards
-          </Button>
-        </div>
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead className="text-left">
-              <tr>
-                <th className="p-2">Time (Duration)</th>
-                <th className="p-2">Name (Host)</th>
-                <th className="p-2">Guests</th>
-                <th className="p-2">Sales Type</th>
-                <th className="p-2">Details</th>
-                <th className="p-2">Action</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr className="border-t">
-                <td className="p-2">6:00 PM (90 min)</td>
-                <td className="p-2">Lee Park</td>
-                <td className="p-2">2</td>
-                <td className="p-2">Walk-in</td>
-                <td className="p-2">Table 4 requested</td>
-                <td className="p-2">
-                  <Button variant="outline" size="sm">
-                    ✏️
-                  </Button>
-                </td>
-              </tr>
-              <tr className="border-t">
-                <td className="p-2">6:30 PM (60 min)</td>
-                <td className="p-2">Chen Wu</td>
-                <td className="p-2">3</td>
-                <td className="p-2">Online</td>
-                <td className="p-2">Birthday party</td>
-                <td className="p-2">
-                  <Button variant="outline" size="sm">
-                    ✏️
-                  </Button>
-                </td>
-              </tr>
-              <tr className="border-t">
-                <td className="p-2">7:00 PM (120 min)</td>
-                <td className="p-2">Kim Davis</td>
-                <td className="p-2">5</td>
-                <td className="p-2">Member</td>
-                <td className="p-2">VIP member</td>
-                <td className="p-2">
-                  <Button variant="outline" size="sm">
-                    ✏️
-                  </Button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </Card>
+      <TodaysReservationsCard />
     </div>
   )
 }
+

--- a/components/dashboard/quick-actions-card.tsx
+++ b/components/dashboard/quick-actions-card.tsx
@@ -1,0 +1,41 @@
+import { Card } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+
+export default function QuickActionsCard() {
+  return (
+    <Card className="glass-card p-4">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+        <h3 className="font-medium">Quick Actions</h3>
+        <div className="flex gap-2" role="tablist">
+          <Button size="sm" className="rounded-full bg-accent px-3 py-1 text-sm hover:bg-accent">
+            🏓 Ping Pong
+          </Button>
+          <Button size="sm" variant="ghost" className="rounded-full px-3 py-1 text-sm hover:bg-accent">
+            ⛳ iGolf
+          </Button>
+          <Button size="sm" variant="ghost" className="rounded-full px-3 py-1 text-sm hover:bg-accent">
+            🎤 Karaoke
+          </Button>
+          <Button size="sm" variant="ghost" className="rounded-full px-3 py-1 text-sm hover:bg-accent">
+            🎱 Billiards
+          </Button>
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <Button variant="outline" size="sm">
+          ➕ Start Session
+        </Button>
+        <Button variant="outline" size="sm">
+          📅 Schedule
+        </Button>
+        <Button variant="outline" size="sm">
+          📝 Order Form
+        </Button>
+        <Button variant="outline" size="sm">
+          🎵 Play Vibe
+        </Button>
+      </div>
+    </Card>
+  )
+}
+

--- a/components/dashboard/recent-activity-card.tsx
+++ b/components/dashboard/recent-activity-card.tsx
@@ -1,0 +1,35 @@
+import { Card } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+
+interface RecentActivityCardProps {
+  activities?: string[]
+}
+
+export default function RecentActivityCard({
+  activities = [
+    "Table P2 session started",
+    "Spotify playlist changed",
+    "New reservation: Kim Davis",
+    "Low inventory alert: Pool Cue Tips",
+  ],
+}: RecentActivityCardProps) {
+  return (
+    <Card className="glass-card p-4">
+      <h3 className="mb-4 font-medium">Recent Activity</h3>
+      <div className="grid gap-2">
+        {activities.map((activity, index) => (
+          <div
+            key={index}
+            className="flex items-center justify-between rounded-md border p-2"
+          >
+            <span>{activity}</span>
+            <Button variant="outline" size="sm">
+              👁️
+            </Button>
+          </div>
+        ))}
+      </div>
+    </Card>
+  )
+}
+

--- a/components/dashboard/todays-reservations-card.tsx
+++ b/components/dashboard/todays-reservations-card.tsx
@@ -1,0 +1,108 @@
+import { Card } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+
+interface Reservation {
+  time: string
+  name: string
+  guests: number
+  salesType: string
+  details: string
+}
+
+interface TodaysReservationsCardProps {
+  reservations?: Reservation[]
+}
+
+export default function TodaysReservationsCard({
+  reservations = [
+    {
+      time: "6:00 PM (90 min)",
+      name: "Lee Park",
+      guests: 2,
+      salesType: "Walk-in",
+      details: "Table 4 requested",
+    },
+    {
+      time: "6:30 PM (60 min)",
+      name: "Chen Wu",
+      guests: 3,
+      salesType: "Online",
+      details: "Birthday party",
+    },
+    {
+      time: "7:00 PM (120 min)",
+      name: "Kim Davis",
+      guests: 5,
+      salesType: "Member",
+      details: "VIP member",
+    },
+  ],
+}: TodaysReservationsCardProps) {
+  return (
+    <Card className="glass-card p-4">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+        <h3 className="font-medium">Today's Reservations</h3>
+        <Button variant="outline" size="sm" className="px-3 py-1">
+          📅 Pull from Google Calendar
+        </Button>
+      </div>
+      <div className="mb-4 flex flex-wrap gap-2">
+        <Button size="sm" className="rounded-md bg-accent px-3 py-1 text-sm">
+          🏓 Ping Pong
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="rounded-md px-3 py-1 text-sm hover:bg-accent"
+        >
+          ⛳ iGolf
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="rounded-md px-3 py-1 text-sm hover:bg-accent"
+        >
+          🎤 Karaoke
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="rounded-md px-3 py-1 text-sm hover:bg-accent"
+        >
+          🎱 Billiards
+        </Button>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="text-left">
+            <tr>
+              <th className="p-2">Time (Duration)</th>
+              <th className="p-2">Name (Host)</th>
+              <th className="p-2">Guests</th>
+              <th className="p-2">Sales Type</th>
+              <th className="p-2">Details</th>
+              <th className="p-2">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {reservations.map((reservation, index) => (
+              <tr key={index} className="border-t">
+                <td className="p-2">{reservation.time}</td>
+                <td className="p-2">{reservation.name}</td>
+                <td className="p-2">{reservation.guests}</td>
+                <td className="p-2">{reservation.salesType}</td>
+                <td className="p-2">{reservation.details}</td>
+                <td className="p-2">
+                  <Button variant="outline" size="sm">
+                    ✏️
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  )
+}
+


### PR DESCRIPTION
## Summary
- split hardcoded dashboard cards into reusable components
- render quick actions, recent activity, and today's reservations cards

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7c5a2428832993e23998e9a0ef7d